### PR TITLE
Add support for later versions of Phantom.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mysql": "^2.7.0",
     "notifyjs": "^1.2.5",
     "pg": "^4.4.0",
-    "phantom": "^0.7.2",
+    "phantom": "^2.0.0-alpha.4",
     "pipe-transformation": "latest",
     "pipe-web-client": "latest",
     "pipend-spy": "latest",


### PR DESCRIPTION
This should close #32.

This updates the phantom-node package to the latest available, which is 2.0.0-alpha.4. I understand if you want to wait for this to stabilize before you pull this in.

Since this is 2 major version bumps, the snapshot code had to be updated to work with the 2.x code.